### PR TITLE
fix: settings cant load bool

### DIFF
--- a/Source/AssetManager.cs
+++ b/Source/AssetManager.cs
@@ -39,7 +39,7 @@ public static class AssetManager
 
     public static Sprite GetSprite(string name, bool allowEE = true, string faction = null, string packName = null, bool skipRegular = false)
     {
-        if (name.Contains("Blank") || !Constants.EnableIcons || IconPacks.Count == 0)
+        if (name.Contains("Blank") || !Constants.EnableIcons() || IconPacks.Count == 0)
             return Blank;
 
         packName ??= Constants.CurrentPack;
@@ -151,7 +151,7 @@ public static class AssetManager
 
     private static void LoadBTOS()
     {
-        if (!Constants.BTOS2Exists)
+        if (!Constants.BTOS2Exists())
             return;
 
         BTOS2Compatibility.BTOS2Patched = BTOS2Compatibility.Init();
@@ -341,7 +341,7 @@ public static class AssetManager
         if (!Vanilla2)
             diagnostic += "\nModified Player Numbers Sheet Does Not Exist";
 
-        if (Constants.BTOS2Exists)
+        if (Constants.BTOS2Exists())
         {
             if (!BTOS2_1)
                 diagnostic += "\nBTOS2 Sheet Does Not Exist";
@@ -352,7 +352,7 @@ public static class AssetManager
 
         diagnostic += $"\nCurrently In A {game} Game";
 
-        if (Constants.EnableIcons && !IconPacks.TryGetValue(Constants.CurrentPack, out pack))
+        if (Constants.EnableIcons() && !IconPacks.TryGetValue(Constants.CurrentPack, out pack))
             diagnostic += "\nNo Loaded Icon Pack";
         else if (pack == null)
             diagnostic += "\nLoaded Icon Pack Was Null";

--- a/Source/BTOS2Compatibility.cs
+++ b/Source/BTOS2Compatibility.cs
@@ -59,7 +59,7 @@ public static class BTOS2Compatibility
 
     public static void ItemPostfix1(dynamic __instance, ref Role a_role, ref FactionType faction, ref bool isBan)
     {
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
             return;
 
         var roleIcon = (Image)AccessTools.Field(DeckItemType, "roleIcon").GetValue(__instance);
@@ -91,7 +91,7 @@ public static class BTOS2Compatibility
 
     public static void ItemPostfix2(dynamic __instance)
     {
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
             return;
 
         var roleIcon = (Image)AccessTools.Field(MenuRoleType, "icon").GetValue(__instance);
@@ -119,7 +119,7 @@ public static class BTOS2Compatibility
 
     public static void ItemPostfix3(dynamic __instance)
     {
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
             return;
 
         var roleIcon = (Image)AccessTools.Field(OracleMenuControllerListItemType, "RoleIcon").GetValue(__instance);

--- a/Source/Constants.cs
+++ b/Source/Constants.cs
@@ -4,15 +4,21 @@ public static class Constants
 {
     public static bool PlayerPanelEasterEggs => ModSettings.GetBool("Enable Easter Eggs In Player Panel", "alchlcsystm.recolors");
     public static bool AllEasterEggs => ModSettings.GetBool("All Easter Eggs Are Active", "alchlcsystm.recolors");
-    public static int EasterEggChance => ModSettings.GetInt("Easter Egg Icon Chance", "alchlcsystm.recolors");
+    public static int EasterEggChance() 
+    { 
+        return ModSettings.GetInt("Easter Egg Icon Chance", "alchlcsystm.recolors"); 
+    }
     public static string CurrentPack => ModSettings.GetString("Selected Icon Pack", "alchlcsystm.recolors");
     public static string CurrentStyle => ModSettings.GetString($"Selected {Utils.GetGameType()} Mention Style", "alchlcsystm.recolors");
     public static string FactionOverride => ModSettings.GetString($"Override {Utils.GetGameType()} Faction", "alchlcsystm.recolors");
     public static bool CustomNumbers => ModSettings.GetBool("Use Custom Numbers", "alchlcsystm.recolors");
     public static bool DumpSheets => ModSettings.GetBool("Dump Sprite Sheets", "alchlcsystm.recolors");
     public static bool FactionOverridden => FactionOverride != "None";
-    public static bool EnableIcons => CurrentPack != "Vanilla";
-    public static bool BTOS2Exists => ModStates.IsEnabled("curtis.tuba.better.tos2");
+    public static bool EnableIcons()
+    {
+        return CurrentPack != "Vanilla";
+    }
+    public static bool BTOS2Exists() { return ModStates.IsEnabled("curtis.tuba.better.tos2"); }
     public static bool IsBTOS2
     {
         get
@@ -27,7 +33,7 @@ public static class Constants
             }
         }
     }
-    private static bool IsBTOS2Bypass() => BTOS2Exists && BetterTOS2.BTOSInfo.IS_MODDED;
+    private static bool IsBTOS2Bypass() => BTOS2Exists() && BetterTOS2.BTOSInfo.IS_MODDED;
     public static bool IsNecroActive
     {
         get

--- a/Source/IconPack.cs
+++ b/Source/IconPack.cs
@@ -86,7 +86,7 @@ public class IconPack(string name)
                 {
                     var assets = Assets[type] = new(mod);
 
-                    if (type == ModType.BTOS2 && !Constants.BTOS2Exists)
+                    if (type == ModType.BTOS2 && !Constants.BTOS2Exists())
                         continue;
 
                     var modPath = Path.Combine(PackPath, mod);
@@ -345,7 +345,7 @@ public class IconPack(string name)
                 {
                     var type = Enum.Parse<ModType>(mod);
 
-                    if (type == ModType.BTOS2 && !Constants.BTOS2Exists)
+                    if (type == ModType.BTOS2 && !Constants.BTOS2Exists())
                         continue;
 
                     var index = Utils.Filtered(type);
@@ -441,7 +441,7 @@ public class IconPack(string name)
         icons ??= [];
         icons.TryGetValue(iconName, out var sprite);
 
-        if (URandom.RandomRangeInt(1, 101) <= Constants.EasterEggChance && (allowEE || !sprite.IsValid()))
+        if (URandom.RandomRangeInt(1, 101) <= Constants.EasterEggChance() && (allowEE || !sprite.IsValid()))
         {
             var sprites = new List<Sprite>();
 

--- a/Source/Main.cs
+++ b/Source/Main.cs
@@ -50,7 +50,7 @@ public class Recolors
         Name = "Selected Vanilla Mention Style",
         Description = "The selected mention style will dictate which icons are used for the icons in text. May require a game restart.",
         Options = GetOptions(ModType.Vanilla, true),
-        Available = Constants.EnableIcons
+        Available = Constants.EnableIcons()
     };
 
     public ModSettings.DropdownSetting ChoiceMentions2 => new()
@@ -58,7 +58,7 @@ public class Recolors
         Name = "Selected BTOS2 Mention Style",
         Description = "The selected mention style will dictate which icons are used for the icons in text. May require a game restart.",
         Options = GetOptions(ModType.BTOS2, true),
-        Available = Constants.BTOS2Exists && Constants.EnableIcons
+        Available = Constants.BTOS2Exists() && Constants.EnableIcons()
     };
 
     public ModSettings.DropdownSetting FactionOverride1 => new()
@@ -66,7 +66,7 @@ public class Recolors
         Name = "Override Vanilla Faction",
         Description = "Only icons from the selected faction will appear in vanilla games.",
         Options = GetOptions(ModType.Vanilla, false),
-        Available = Constants.EnableIcons
+        Available = Constants.EnableIcons()
     };
 
     public ModSettings.DropdownSetting FactionOverride2 => new()
@@ -74,14 +74,14 @@ public class Recolors
         Name = "Override BTOS2 Faction",
         Description = "Only icons from the selected faction will appear in BTOS2 games.",
         Options = GetOptions(ModType.BTOS2, false),
-        Available = Constants.BTOS2Exists && Constants.EnableIcons
+        Available = Constants.BTOS2Exists() && Constants.EnableIcons()
     };
 
     public ModSettings.CheckboxSetting CustomNumbers => new()
     {
         Name = "Use Custom Numbers",
         Description = "Select whether you want to use the icon pack's rendition of player numbers or the game's.",
-        Available = Constants.EnableIcons
+        Available = Constants.EnableIcons()
     };
 
     public ModSettings.IntegerInputSetting EasterEggChance => new()
@@ -90,7 +90,7 @@ public class Recolors
         Description = "The chance of a different than normal icon appearing for roles.",
         DefaultValue = 5,
         AvailableInGame = true,
-        Available = Constants.EnableIcons
+        Available = Constants.EnableIcons()
     };
 
     public ModSettings.CheckboxSetting AllEasterEggs => new()
@@ -99,7 +99,7 @@ public class Recolors
         Description = "Toggles whether all of the previously selected icon pack's easter eggs will be used, or only the selected icon pack's.",
         DefaultValue = false,
         AvailableInGame = true,
-        Available = Constants.EnableIcons && Constants.EasterEggChance > 0
+        Available = Constants.EnableIcons() && (Constants.EasterEggChance() > 0)
     };
 
     public ModSettings.CheckboxSetting PlayerPanelEasterEggs => new()
@@ -108,7 +108,7 @@ public class Recolors
         Description = "Toggles whether easter egg icons appear or not in the ability panel.",
         DefaultValue = false,
         AvailableInGame = true,
-        Available = Constants.EnableIcons && Constants.EasterEggChance > 0
+        Available = Constants.EnableIcons() && (Constants.EasterEggChance() > 0)
     };
 
     private static List<string> GetPackNames()

--- a/Source/Patches.cs
+++ b/Source/Patches.cs
@@ -17,7 +17,7 @@ public static class PatchRoleDeckBuilder
 {
     public static void Postfix(RoleCardListItem __instance, ref Role role)
     {
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
             return;
 
         var icon = AssetManager.GetSprite(Utils.RoleName(role), Utils.FactionName(role.GetFactionType()), false);
@@ -38,7 +38,7 @@ public static class PatchRoleListPanel
 {
     public static void Postfix(RoleDeckListItem __instance, ref Role a_role, ref bool a_isBan)
     {
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
             return;
 
         var icon = a_isBan ? AssetManager.GetSprite("Banned", false) : AssetManager.GetSprite(Utils.RoleName(a_role), Utils.FactionName(a_role.GetFactionType()), false);
@@ -53,7 +53,7 @@ public static class PatchBrowserRoleListPanel
 {
     public static void Postfix(GameBrowserRoleDeckListItem __instance, ref Role a_role, ref bool a_isBan)
     {
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
             return;
 
         var icon = a_isBan ? AssetManager.GetSprite("Banned", false) : AssetManager.GetSprite(Utils.RoleName(a_role), Utils.FactionName(a_role.GetFactionType()), false);
@@ -69,7 +69,7 @@ public static class PatchRoleCards
     [HarmonyPatch(typeof(RoleCardPanelBackground), nameof(RoleCardPanelBackground.SetRole))]
     public static void Postfix(RoleCardPanelBackground __instance, ref Role role)
     {
-        if (Constants.EnableIcons)
+        if (Constants.EnableIcons())
         {
             var panel = __instance.GetComponentInParent<RoleCardPanel>();
             ChangeRoleCard(panel?.roleIcon, panel?.specialAbilityPanel?.useButton?.abilityIcon, panel?.roleInfoButtons, role, Pepper.GetMyFaction());
@@ -79,14 +79,14 @@ public static class PatchRoleCards
     [HarmonyPatch(typeof(RoleCardPanel), nameof(RoleCardPanel.HandleOnMyIdentityChanged))]
     public static void Postfix(RoleCardPanel __instance, ref PlayerIdentityData playerIdentityData)
     {
-        if (Constants.EnableIcons)
+        if (Constants.EnableIcons())
             ChangeRoleCard(__instance?.roleIcon, __instance?.specialAbilityPanel?.useButton?.abilityIcon, __instance?.roleInfoButtons, playerIdentityData.role, playerIdentityData.faction);
     }
 
     [HarmonyPatch(typeof(RoleCardPopupPanel), nameof(RoleCardPopupPanel.SetRole))]
     public static void Postfix(RoleCardPopupPanel __instance, ref Role role)
     {
-        if (Constants.EnableIcons)
+        if (Constants.EnableIcons())
             ChangeRoleCard(__instance?.roleIcon, __instance?.specialAbilityPanel?.useButton?.abilityIcon, __instance?.roleInfoButtons, role, role.GetFactionType(), true);
     }
 
@@ -212,7 +212,7 @@ public static class PatchAbilityPanel
 {
     public static void Postfix(TosAbilityPanelListItem __instance, ref TosAbilityPanelListItem.OverrideAbilityType overrideType)
     {
-        if (!Constants.EnableIcons || overrideType == TosAbilityPanelListItem.OverrideAbilityType.VOTING)
+        if (!Constants.EnableIcons() || overrideType == TosAbilityPanelListItem.OverrideAbilityType.VOTING)
             return;
 
         var role = Pepper.GetMyRole();
@@ -325,7 +325,7 @@ public static class SpecialAbilityPanelPatch
 {
     public static void Postfix(SpecialAbilityPopupGenericListItem __instance)
     {
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
             return;
 
         var role = Pepper.GetMyRole();
@@ -348,7 +348,7 @@ public static class PatchRitualistGuessMenu
 {
     public static void Postfix(SpecialAbilityPopupRadialIcon __instance, ref Role a_role)
     {
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
             return;
 
         var icon = AssetManager.GetSprite(Utils.RoleName(a_role), Utils.FactionName(a_role.GetFactionType()), false);
@@ -398,7 +398,7 @@ public static class PatchAttackDefense
 {
     public static void Postfix(RoleCardPanel __instance, ref RoleCardData data)
     {
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
             return;
 
         var attack = AssetManager.GetSprite($"Attack{Utils.GetLevel(data.attack, true)}");
@@ -421,7 +421,7 @@ public static class PatchAttackDefensePopup
 {
     public static void Postfix(RoleCardPopupPanel __instance, ref RoleCardData data)
     {
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
             return;
 
         var attack = AssetManager.GetSprite($"Attack{Utils.GetLevel(data.attack, true)}");
@@ -444,7 +444,7 @@ public static class PlayerPopupControllerPatch
 {
     public static void Postfix(PlayerPopupController __instance)
     {
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
             return;
 
         var killRecord = Service.Game.Sim.simulation.killRecords.Data.Find(k => k.playerId == __instance.m_discussionPlayerState.position);
@@ -471,7 +471,7 @@ public static class InitialiseRolePanel
 {
     public static void Postfix(PlayerPopupController __instance)
     {
-        if (!Constants.EnableIcons || !Pepper.IsGamePhasePlay())
+        if (!Constants.EnableIcons() || !Pepper.IsGamePhasePlay())
             return;
 
         var killRecord = Service.Game.Sim.simulation.killRecords.Data.Find(k => k.playerId == __instance.m_discussionPlayerState.position);
@@ -507,7 +507,7 @@ public static class RoleMenuPopupControllerPatch
 {
     public static void Postfix(RoleMenuPopupController __instance)
     {
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
             return;
 
         var sprite = AssetManager.GetSprite(Utils.RoleName(__instance.m_role), Utils.FactionName(__instance.m_role.GetFactionType()));
@@ -533,7 +533,7 @@ public static class PlayerEffectsServicePatch
         if (!EffectSprites.ContainsKey(effectType))
             EffectSprites[effectType] = __result.sprite;
 
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
         {
             __result.sprite = EffectSprites[effectType];
             return;
@@ -554,7 +554,7 @@ public static class GetRoleIconAndNameInlineStringPatch
 {
     public static void Postfix(ref FactionType factionType, ref string __result)
     {
-        if (Constants.EnableIcons)
+        if (Constants.EnableIcons())
             __result = __result.Replace("RoleIcons\"", $"RoleIcons ({Utils.FactionName(factionType, false)})\"");
     }
 }
@@ -564,7 +564,7 @@ public static class GetTownTraitorRoleIconAndNameInlineStringPatch
 {
     public static void Postfix(ref string __result)
     {
-        if (Constants.EnableIcons)
+        if (Constants.EnableIcons())
             __result = __result.Replace("RoleIcons\"", "RoleIcons (Coven)\"");
     }
 }
@@ -574,7 +574,7 @@ public static class GetVIPRoleIconAndNameInlineStringPatch
 {
     public static void Postfix(ref string __result)
     {
-        if (Constants.EnableIcons)
+        if (Constants.EnableIcons())
             __result = __result.Replace("RoleIcons\"", "RoleIcons (VIP)\"") + " <sprite=\"RoleIcons (VIP)\" name=\"Role201\">";
     }
 }
@@ -584,7 +584,7 @@ public static class TosCharacterNametagPatch
 {
     public static void Postfix(TosCharacterNametag __instance, ref FactionType factionType, ref string __result)
     {
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
             return;
 
         if (__instance.tosCharacter.position == Pepper.GetMyPosition())
@@ -600,7 +600,7 @@ public static class FixDecodingAndEncoding
 {
     public static void Postfix(ref ChatLogMessage chatLogMessage, ref string __result)
     {
-        if (Constants.EnableIcons && chatLogMessage.chatLogEntry is ChatLogChatMessageEntry entry)
+        if (Constants.EnableIcons() && chatLogMessage.chatLogEntry is ChatLogChatMessageEntry entry)
         {
             var faction = "Regular";
 
@@ -621,7 +621,7 @@ public static class PMBakerMenuPatch
 {
     public static void Postfix(SpecialAbilityPopupPotionMaster __instance)
     {
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
             return;
 
         var role = Pepper.GetMyRole();
@@ -727,7 +727,7 @@ public static class ReplaceTMPSpritesPatch
     {
         asset = null;
 
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
             return false;
 
         if (AssetManager.IconPacks.TryGetValue(Constants.CurrentPack, out var pack))
@@ -804,7 +804,7 @@ public static class NecroPassPatches
     [HarmonyPostfix]
     public static void RefreshDataPatch(NecroPassingVoteEntry __instance)
     {
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
             return;
 
         var nommy = AssetManager.GetSprite("Necronomicon");
@@ -834,7 +834,7 @@ public static class NecroPassPatches
     [HarmonyPostfix]
     public static void UpdateVoteStatePatch(NecroPassingVoteEntry __instance)
     {
-        if (!Constants.EnableIcons)
+        if (!Constants.EnableIcons())
             return;
 
         for (var i = 0; i < __instance.m_votes.Count; i++)


### PR DESCRIPTION
fixes dynamic settings being unable to load a bool as it does not call 

explanation:
1. go here https://www.programiz.com/csharp-programming/online-compiler/

2. paste this
```cs
using System;

class Program
{
    static int Toggled = 0;
    static bool ThisIsACompiledConditionNow => Toggled == 0;
    static void Main(string[] args) {
        Setting aNewSetting = new() {
            Name = "Very Cool Setting",
            // here!! it sets the below value just to Available instead of calling the function every time
            Available = ThisIsACompiledConditionNow
        };
        
        Console.WriteLine($"{aNewSetting.Name}, {aNewSetting.Available}, {Toggled}, {ThisIsACompiledConditionNow}");
        
        Toggled = 1;
        Console.WriteLine($"{aNewSetting.Name}, {aNewSetting.Available}, {Toggled}, {ThisIsACompiledConditionNow}");
    }
}

public class Setting
{
    public string Name;
    public bool Available = true;
}
```

3. run the code

Also you should have fallbacks for these settings not loading (see [this log in discord](https://discord.com/channels/1197645970998054992/1201509914984587335/1245011962262192198))