### PR TITLE
Many things I ain't listing in the title

### DIFF
--- a/Source/Patches/IPPatches.cs
+++ b/Source/Patches/IPPatches.cs
@@ -647,7 +647,7 @@ public static class PMBakerMenuPatch
 
         var sprite1 = GetSprite(reg, $"{name}_Ability_1", faction);
         var sprite2 = GetSprite(reg, $"{name}_Ability_2", faction);
-        var sprite3 = GetSprite(reg, $"{name}_Special", faction);
+        var sprite3 = GetSprite(reg, $"{name}_Ability_3", faction);
 
         if (!sprite1.IsValid() && reg)
             sprite1 = GetSprite($"{name}_Ability_1", ogfaction);
@@ -656,7 +656,7 @@ public static class PMBakerMenuPatch
             sprite2 = GetSprite($"{name}_Ability_2", ogfaction);
 
         if (!sprite3.IsValid() && reg)
-            sprite3 = GetSprite($"{name}_Special", ogfaction);
+            sprite3 = GetSprite($"{name}_Ability_3", ogfaction);
 
         var image1 = __instance.transform.Find("Background/ShieldPotion").GetComponentInChildren<Image>();
         var image2 = __instance.transform.Find("Background/RevealPotion").GetComponentInChildren<Image>();

--- a/Source/Patches/IPPatches.cs
+++ b/Source/Patches/IPPatches.cs
@@ -647,7 +647,7 @@ public static class PMBakerMenuPatch
 
         var sprite1 = GetSprite(reg, $"{name}_Ability_1", faction);
         var sprite2 = GetSprite(reg, $"{name}_Ability_2", faction);
-        var sprite3 = GetSprite(reg, $"{name}_Special", faction);
+        var sprite3 = GetSprite(reg, $"{name}_Ability_3", faction);
 
         if (!sprite1.IsValid() && reg)
             sprite1 = GetSprite($"{name}_Ability_1", faction);
@@ -656,7 +656,7 @@ public static class PMBakerMenuPatch
             sprite2 = GetSprite($"{name}_Ability_2", faction);
 
         if (!sprite3.IsValid() && reg)
-            sprite3 = GetSprite($"{name}_Special", faction);
+            sprite3 = GetSprite($"{name}_Ability_3", faction);
 
         var image1 = __instance.transform.Find("Background/ShieldPotion").GetComponentInChildren<Image>();
         var image2 = __instance.transform.Find("Background/RevealPotion").GetComponentInChildren<Image>();

--- a/Source/Patches/IPPatches.cs
+++ b/Source/Patches/IPPatches.cs
@@ -234,10 +234,18 @@ public static class PatchRoleCards
             return;
 
         index++;
-        var nommy = GetSprite("Necronomicon");
+        var nommy = GetSprite($"Necronomicon_{faction}");
+
+        if (!nommy.IsValid())
+        {
+            nommy = GetSprite("Necronomicon");
+        }
 
         if (nommy.IsValid() && (Constants.IsNecroActive() || isGuide) && roleInfoButtons.IsValid(index))
+        {
             roleInfoButtons[index].abilityIcon.sprite = nommy;
+        }
+
     }
 }
 

--- a/Source/Patches/IPPatches.cs
+++ b/Source/Patches/IPPatches.cs
@@ -647,16 +647,16 @@ public static class PMBakerMenuPatch
 
         var sprite1 = GetSprite(reg, $"{name}_Ability_1", faction);
         var sprite2 = GetSprite(reg, $"{name}_Ability_2", faction);
-        var sprite3 = GetSprite(reg, $"{name}_Ability_3", faction);
+        var sprite3 = GetSprite(reg, $"{name}_Special", faction);
 
         if (!sprite1.IsValid() && reg)
-            sprite1 = GetSprite($"{name}_Ability_1", ogfaction);
+            sprite1 = GetSprite($"{name}_Ability_1", faction);
 
         if (!sprite2.IsValid() && reg)
-            sprite2 = GetSprite($"{name}_Ability_2", ogfaction);
+            sprite2 = GetSprite($"{name}_Ability_2", faction);
 
         if (!sprite3.IsValid() && reg)
-            sprite3 = GetSprite($"{name}_Ability_3", ogfaction);
+            sprite3 = GetSprite($"{name}_Special", faction);
 
         var image1 = __instance.transform.Find("Background/ShieldPotion").GetComponentInChildren<Image>();
         var image2 = __instance.transform.Find("Background/RevealPotion").GetComponentInChildren<Image>();

--- a/Source/Patches/IPPatches.cs
+++ b/Source/Patches/IPPatches.cs
@@ -188,6 +188,20 @@ public static class PatchRoleCards
         else if (Utils.Skippable(abilityname2))
             index++;
 
+        var abilityname3 = $"{name}_Ability_3";
+        var ability3 = GetSprite(reg, abilityname3, faction);
+
+        if (!ability3.IsValid() && reg)
+            ability3 = GetSprite(abilityname3, ogfaction);
+
+        if (ability3.IsValid() && roleInfoButtons.IsValid(index))
+        {
+            roleInfoButtons[index].abilityIcon.sprite = ability3;
+            index++;
+        }
+        else if (Utils.Skippable(abilityname3))
+            index++;
+
         var attribute = GetSprite(reg, $"Attributes_{name}_Role", faction);
 
         if (!attribute.IsValid())

--- a/Source/Utils.cs
+++ b/Source/Utils.cs
@@ -444,7 +444,7 @@ public static class Utils
         EffectType.LOVER => "Lover",
         EffectType.DOUSED => "Doused",
         EffectType.PLAGUED => "Plagued",
-        EffectType.NECRONOMICON => "Necronomicon",
+        EffectType.NECRONOMICON => "NecroHolder",
         EffectType.TRAPPED => "Trapped",
         EffectType.BREAD => "Bread",
         EffectType.HANGOVER => "Hangover",


### PR DESCRIPTION
- PotionMaster_Special will now replace the special ability icon.
- PotionMaster_Ability_3 will replace the Kill Potion in the Potion Master UI.
BTOS2 Baker gets the same treatment (they use the same code)
- Potion Master UI will now change the potions depending on faction
- Necronomicon on role card can now be factional (green book real)
- Added "NecroHolder", which is for the Necronomicon effect type, which allows for a unique icon for it (because I wanted it)