### PR TITLE
Fix Ability_3 appearing in role card + Fix Special appearing in player list as Potion Master

### DIFF
--- a/Source/Patches/IPPatches.cs
+++ b/Source/Patches/IPPatches.cs
@@ -188,20 +188,6 @@ public static class PatchRoleCards
         else if (Utils.Skippable(abilityname2))
             index++;
 
-        var abilityname3 = $"{name}_Ability_3";
-        var ability3 = GetSprite(reg, abilityname3, faction);
-
-        if (!ability3.IsValid() && reg)
-            ability3 = GetSprite(abilityname3, ogfaction);
-
-        if (ability3.IsValid() && roleInfoButtons.IsValid(index))
-        {
-            roleInfoButtons[index].abilityIcon.sprite = ability3;
-            index++;
-        }
-        else if (Utils.Skippable(abilityname3))
-            index++;
-
         var attribute = GetSprite(reg, $"Attributes_{name}_Role", faction);
 
         if (!attribute.IsValid() && role.IsTransformedApoc())

--- a/Source/Patches/IPPatches.cs
+++ b/Source/Patches/IPPatches.cs
@@ -280,13 +280,25 @@ public static class PatchAbilityPanel
 
                 break;
             }
-            case TosAbilityPanelListItem.OverrideAbilityType.POTIONMASTER_ATTACK or TosAbilityPanelListItem.OverrideAbilityType.POISONER_POISON or
+            case TosAbilityPanelListItem.OverrideAbilityType.POISONER_POISON or
                 TosAbilityPanelListItem.OverrideAbilityType.SHROUD or TosAbilityPanelListItem.OverrideAbilityType.INVESTIGATOR or TosAbilityPanelListItem.OverrideAbilityType.PIRATE:
             {
                 var special = GetSprite(reg, $"{name}_Special", faction, Constants.PlayerPanelEasterEggs());
 
                 if (!special.IsValid() && reg)
                     special = GetSprite($"{name}_Special", ogfaction, Constants.PlayerPanelEasterEggs());
+
+                if (special.IsValid() && __instance.choice1Sprite)
+                    __instance.choice1Sprite.sprite = special;
+
+                break;
+            }
+            case TosAbilityPanelListItem.OverrideAbilityType.POTIONMASTER_ATTACK:
+            {
+                var special = GetSprite(reg, $"{name}_Ability_3", faction, Constants.PlayerPanelEasterEggs());
+
+                if (!special.IsValid() && reg)
+                    special = GetSprite($"{name}_Ability_3", ogfaction, Constants.PlayerPanelEasterEggs());
 
                 if (special.IsValid() && __instance.choice1Sprite)
                     __instance.choice1Sprite.sprite = special;


### PR DESCRIPTION
Found this with the most recent Fancy UI version.

PotionMaster_Ability_3 is included in the ability index, meaning it replaces Attributes and also has Attributes replace Necronomicon.
BTOS2 Baker has the same issue, except you can't see the Attributes.

Don't worry, the intended purpose of Ability_3 still works.