### PR TITLE
Role Reveal now changes roles based on faction [by Synapsium]

### DIFF
--- a/Source/Patches/ModPatches.cs
+++ b/Source/Patches/ModPatches.cs
@@ -177,26 +177,38 @@ public static class PatchDefaultWinScreens
 [HarmonyPatch(typeof(RoleRevealCinematicPlayer), nameof(RoleRevealCinematicPlayer.SetRole))]
 public static class RoleRevealCinematicPlayerPatch
 {
-    public static bool Prefix(RoleRevealCinematicPlayer __instance, ref Role role)
-    {
-        if (!Constants.IconsInRoleReveal() || role == Role.NONE)
-            return true;
-
-        var newValue = $"<sprite=\"Cast\" name=\"Skin{__instance.roleRevealCinematic.skinId}\">{Service.Game.Cast.GetSkinName(__instance.roleRevealCinematic.skinId)}";
-        var text = __instance.l10n("CINE_ROLE_REVEAL_SKIN").Replace("%skin%", newValue);
-        __instance.skinTextPlayer.ShowText(text);
-
-        __instance.totalDuration = Tuning.ROLE_REVEAL_TIME;
-        __instance.silhouetteWrapper.gameObject.SetActive(true);
-        __instance.silhouetteWrapper.SwapWithSilhouette((int)role);
-
-        var newValue2 = role.GetTMPSprite() + role.ToColorizedDisplayString();
-        var text2 = __instance.l10n("CINE_ROLE_REVEAL_ROLE").Replace("%role%", newValue2);
-        __instance.roleTextPlayer.ShowText(text2);
-
-        if (Pepper.GetCurrentGameType() == GameType.Ranked)
-            __instance.playableDirector.Resume();
-
-        return false;
-    }
+		public static bool Prefix(RoleRevealCinematicPlayer __instance, ref Role role)
+		{
+			if (role == Role.NONE)
+			{
+				return true;
+			}
+			bool flag = Constants.IconsInRoleReveal();
+			string newValue = flag ? string.Format("<sprite=\"Cast\" name=\"Skin{0}\">{1}", __instance.roleRevealCinematic.skinId, Service.Game.Cast.GetSkinName(__instance.roleRevealCinematic.skinId)) : Service.Game.Cast.GetSkinName(__instance.roleRevealCinematic.skinId);
+			string text = __instance.l10n("CINE_ROLE_REVEAL_SKIN").Replace("%skin%", newValue);
+			__instance.skinTextPlayer.ShowText(text);
+			__instance.totalDuration = Tuning.ROLE_REVEAL_TIME;
+			__instance.silhouetteWrapper.gameObject.SetActive(true);
+			__instance.silhouetteWrapper.SwapWithSilhouette((int)role, true);
+			string newValue2 = flag ? (role.GetTMPSprite() + role.ToColorizedDisplayString(RoleRevealCinematicIdentityPatch.currentFaction)) : role.ToColorizedDisplayString(RoleRevealCinematicIdentityPatch.currentFaction);
+			newValue2 = newValue2.Replace("RoleIcons\"", "RoleIcons (" + ((role.GetFactionType(null) == RoleRevealCinematicIdentityPatch.currentFaction && Constants.CurrentStyle(null) == "Regular") ? "Regular" : Utils.FactionName(RoleRevealCinematicIdentityPatch.currentFaction, false, null)) + ")\"");
+			string text2 = __instance.l10n("CINE_ROLE_REVEAL_ROLE").Replace("%role%", newValue2);
+			__instance.roleTextPlayer.ShowText(text2);
+			if (Pepper.GetCurrentGameType() == GameType.Ranked)
+			{
+				__instance.playableDirector.Resume();
+			}
+			return false;
+		}
 }
+
+[HarmonyPatch(typeof(RoleRevealCinematicPlayer), nameof(RoleRevealCinematicPlayer.HandleOnMyIdentityChanged))]
+	public static class RoleRevealCinematicIdentityPatch
+	{
+		public static void Prefix(RoleRevealCinematicPlayer __instance, ref PlayerIdentityData playerIdentity)
+		{
+			RoleRevealCinematicIdentityPatch.currentFaction = playerIdentity.faction;
+		}
+
+		public static FactionType currentFaction;
+	}

--- a/Source/Resources/StringTable.xml
+++ b/Source/Resources/StringTable.xml
@@ -71,8 +71,8 @@
     <Entry key="FANCY_SHOW_TO_JAILOR_NAME">Show Jail Overlay When Jailing</Entry>
     <Entry key="FANCY_SHOW_TO_JAILOR_DESC">When you are jailing someone as the Jailor, this option makes the old jailor overlay appear on your screen.</Entry>
 
-    <Entry key="FANCY_ROLE_REVEAL_ICONS_NAME">Icons In Role Reveal Cinematic</Entry>
-    <Entry key="FANCY_ROLE_REVEAL_ICONS_DESC">Shows the character headshot and role icon at their respective locations during the role reveal cinematic.</Entry>
+    <Entry key="FANCY_ROLE_REVEAL_ICONS_NAME">Fancy Up Role Reveal Cinematic</Entry>
+    <Entry key="FANCY_ROLE_REVEAL_ICONS_DESC">Shows the character headshot and role icon at their respective locations during the role reveal cinematic. It will also recolor the colored role name in the cinematic with your current faction (supports Pandora, Compliance, and Teams).</Entry>
 
 
     <Entry key="FANCY_DEFAULT">Default</Entry>


### PR DESCRIPTION
The role reveal cinematic will now recolor the role name with your respective faction.
Supports Pandora, Compliance, and Teams.

Compliance (with colors changed with MRC):
![image](https://github.com/user-attachments/assets/a168c5f3-a0df-461c-a232-51eab18197d9)

Pandora (with colors changed with MRC):
![image](https://github.com/user-attachments/assets/08f134ee-a6fc-40d0-b49b-87de7f000cef)

Lions Amnesiac:
![image](https://github.com/user-attachments/assets/69bbc6fc-637e-410e-aa48-29c9a69ad72c)
