### PR TITLE
Factional Colored Wood

### DIFF
--- a/Source/Constants.cs
+++ b/Source/Constants.cs
@@ -1,3 +1,5 @@
+using Home.Shared;
+
 namespace FancyUI;
 
 public static class Constants
@@ -38,19 +40,49 @@ public static class Constants
 
     public static float AnimationDuration() => Fancy.AnimationDuration.Value;
 
-    private static UITheme GetMainUIThemeType() => Fancy.SelectedUITheme.Value;
+    public static UITheme GetMainUIThemeType() => Fancy.SelectedUITheme.Value;
 
-    public static Color GetMainUIThemeWoodColor() => Fancy.MainUIThemeWood.Value.ToColor();
+   public static Color GetMainUIThemeWoodColor() => GetMainUIThemeType() switch
+    {
+        UITheme.Faction when Pepper.GetMyFaction() != FactionType.NONE
+            => Pepper.GetMyFaction().GetFactionColor().ToColor().ShadeColor((float)Fancy.WoodShade.Value / 100),
+        _ => Fancy.MainUIThemeWood.Value.ToColor(),
+    };
 
-    public static Color GetMainUIThemeMetalColor() => Fancy.MainUIThemeMetal.Value.ToColor();
+    public static Color GetMainUIThemeMetalColor() => GetMainUIThemeType() switch
+    {
+        UITheme.Faction when Pepper.GetMyFaction() != FactionType.NONE
+            => Pepper.GetMyFaction().GetFactionColor().ToColor().ShadeColor((float)Fancy.MetalShade.Value / 100),
+        _ => Fancy.MainUIThemeMetal.Value.ToColor(),
+    };
 
-    public static Color GetMainUIThemePaperColor() => Fancy.MainUIThemePaper.Value.ToColor();
+    public static Color GetMainUIThemePaperColor() => GetMainUIThemeType() switch
+    {
+        UITheme.Faction when Pepper.GetMyFaction() != FactionType.NONE
+            => Pepper.GetMyFaction().GetFactionColor().ToColor().ShadeColor((float)Fancy.PaperShade.Value / 100),
+        _ => Fancy.MainUIThemePaper.Value.ToColor(),
+    };
 
-    public static Color GetMainUIThemeLeatherColor() => Fancy.MainUIThemeLeather.Value.ToColor();
+    public static Color GetMainUIThemeLeatherColor() => GetMainUIThemeType() switch
+    {
+        UITheme.Faction when Pepper.GetMyFaction() != FactionType.NONE
+            => Pepper.GetMyFaction().GetFactionColor().ToColor().ShadeColor((float)Fancy.LeatherShade.Value / 100),
+        _ => Fancy.MainUIThemeLeather.Value.ToColor(),
+    };
 
-    public static Color GetMainUIThemeFireColor() => Fancy.MainUIThemeFire.Value.ToColor();
+    public static Color GetMainUIThemeFireColor() => GetMainUIThemeType() switch
+    {
+        UITheme.Faction when Pepper.GetMyFaction() != FactionType.NONE
+            => Pepper.GetMyFaction().GetFactionColor().ToColor().ShadeColor((float)Fancy.FireShade.Value / 100),
+        _ => Fancy.MainUIThemeFire.Value.ToColor(),
+    };
 
-    public static Color GetMainUIThemeWaxColor() => Fancy.MainUIThemeWax.Value.ToColor();
+    public static Color GetMainUIThemeWaxColor() => GetMainUIThemeType() switch
+    {
+        UITheme.Faction when Pepper.GetMyFaction() != FactionType.NONE
+            => Pepper.GetMyFaction().GetFactionColor().ToColor().ShadeColor((float)Fancy.WaxShade.Value / 100),
+        _ => Fancy.MainUIThemeWax.Value.ToColor(),
+    };
 
     public static int PlayerNumber() => (int)Fancy.PlayerNumber.Value;
 
@@ -60,7 +92,7 @@ public static class Constants
 
     public static bool EnableSwaps() => CurrentSet() != "Vanilla";
 
-    public static bool EnableCustomUI() => GetMainUIThemeType() != UITheme.Default;
+    public static bool EnableCustomUI() => GetMainUIThemeType() != UITheme.Vanilla;
 
     public static bool BTOS2Exists() => ModStates.IsEnabled("curtis.tuba.better.tos2");
 

--- a/Source/Fancy.cs
+++ b/Source/Fancy.cs
@@ -109,6 +109,13 @@ public class Fancy
     public static ToggleOption ShowOverlayAsJailor;
     public static ToggleOption IconsInRoleReveal;
 
+    public static FloatOption WoodShade;
+    public static FloatOption PaperShade;
+    public static FloatOption MetalShade;
+    public static FloatOption LeatherShade;
+    public static FloatOption FireShade;
+    public static FloatOption WaxShade;
+
     [LoadConfigs]
     public static void LoadConfigs()
     {
@@ -116,7 +123,7 @@ public class Fancy
         SelectedSilhouetteSet = new("SELECTED_SIL_SET", "Vanilla", PackType.SilhouetteSets, () => GetPackNames(PackType.SilhouetteSets), onChanged: x => TryLoadingSprites(x,
             PackType.SilhouetteSets));
 
-        SelectedUITheme = new("SELECTED_UI_THEME", UITheme.Default, PackType.RecoloredUI, useTranslations: true);
+        SelectedUITheme = new("SELECTED_UI_THEME", UITheme.Vanilla, PackType.RecoloredUI, useTranslations: true);
 
         MentionStyle1 = new("MENTION_STYLE_1", "Regular", PackType.IconPacks, () => GetOptions(ModType.Vanilla, true), _ => Constants.EnableIcons());
         MentionStyle2 = new("MENTION_STYLE_2", "Regular", PackType.IconPacks, () => GetOptions(ModType.BTOS2, true), _ => Constants.BTOS2Exists() && Constants.EnableIcons());
@@ -131,6 +138,13 @@ public class Fancy
         MainUIThemeWood = new("UI_WOOD", "#FFFFFF", PackType.RecoloredUI, _ => Constants.EnableCustomUI());
         MainUIThemeWax = new("UI_WAX", "#FFFFFF", PackType.RecoloredUI, _ => Constants.EnableCustomUI());
 
+        FireShade = new("FIRE_SHADE", 0, PackType.RecoloredUI, -100, 100, true, _ => Constants.EnableCustomUI());
+        PaperShade = new("PAPER_SHADE", 0, PackType.RecoloredUI, -100, 100, true, _ => Constants.EnableCustomUI());
+        MetalShade = new("METAL_SHADE", 0, PackType.RecoloredUI, -100, 100, true, _ => Constants.EnableCustomUI());
+        LeatherShade = new("LEATHER_SHADE", 0, PackType.RecoloredUI, -100, 100, true, _ => Constants.EnableCustomUI());
+        WoodShade = new("WOOD_SHADE", 0, PackType.RecoloredUI, -100, 100, true, _ => Constants.EnableCustomUI());
+        WaxShade = new("WAX_SHADE", 0, PackType.RecoloredUI, -100, 100, true, _ => Constants.EnableCustomUI());
+
         PlayerNumber = new("PLAYER_NUMBER", 0, PackType.IconPacks, 0, 15, true, _ => Constants.CustomNumbers());
 
         EasterEggChance = new("EE_CHANCE", 5, PackType.IconPacks, 0, 100, true, _ => Constants.EnableIcons());
@@ -139,11 +153,11 @@ public class Fancy
         CustomNumbers = new("CUSTOM_NUMBERS", false, PackType.IconPacks, _ => Constants.EnableIcons());
         AllEasterEggs = new("ALL_EE", false, PackType.IconPacks, _ => Constants.EnableIcons());
         PlayerPanelEasterEggs = new("PLAYER_PANEL_EE", false, PackType.IconPacks, _ => Constants.EnableIcons());
-        DumpSpriteSheets = new("DUMP_SHEETS", false, PackType.Settings);
-        DebugPackLoading = new("DEBUG_LOADING", false, PackType.Settings);
-        ShowOverlayWhenJailed = new("SHOW_TO_JAILED", true, PackType.Settings);
-        ShowOverlayAsJailor = new("SHOW_TO_JAILOR", false, PackType.Settings);
-        IconsInRoleReveal = new("ROLE_REVEAL_ICONS", true, PackType.Settings);
+        DumpSpriteSheets = new("DUMP_SHEETS", false, PackType.Testing);
+        DebugPackLoading = new("DEBUG_LOADING", false, PackType.Testing);
+        ShowOverlayWhenJailed = new("SHOW_TO_JAILED", true, PackType.Testing);
+        ShowOverlayAsJailor = new("SHOW_TO_JAILOR", false, PackType.Testing);
+        IconsInRoleReveal = new("ROLE_REVEAL_ICONS", true, PackType.Testing);
     }
 
     private static IEnumerable<string> GetPackNames(PackType type)

--- a/Source/FancyUIEnums.cs
+++ b/Source/FancyUIEnums.cs
@@ -14,7 +14,7 @@ public enum PackType : byte
     RecoloredUI,
     SilhouetteSets,
     MiscRoleCustomisation,
-    Settings
+    Testing
 }
 
 public enum ColorType : byte
@@ -29,8 +29,7 @@ public enum ColorType : byte
 
 public enum UITheme : byte
 {
-    Default,
-    Role,
+    Vanilla,
     Faction,
     Custom
 }

--- a/Source/Resources/StringTable.xml
+++ b/Source/Resources/StringTable.xml
@@ -39,23 +39,41 @@
     <Entry key="FANCY_ANIM_DURATION_DESC">Dictates how long should one iteration of an animation last for.</Entry>
 
     <Entry key="FANCY_UI_FIRE_NAME">Custom UI Theme Fire Color</Entry>
-    <Entry key="FANCY_UI_FIRE_DESC">Dictates how the fire of the main UI loooks like.</Entry>
+    <Entry key="FANCY_UI_FIRE_DESC">Dictates how the fire of the main UI looks like.</Entry>
+
+    <Entry key="FANCY_FIRE_SHADE_NAME">Faction UI Theme Fire Shading</Entry>
+    <Entry key="FANCY_FIRE_SHADE_DESC">Dictates how dark or light the faction fire color will be.</Entry>
 
     <Entry key="FANCY_UI_PAPER_NAME">Custom UI Theme Paper Color</Entry>
-    <Entry key="FANCY_UI_PAPER_DESC">Dictates how the paper of the main UI loooks like.</Entry>
+    <Entry key="FANCY_UI_PAPER_DESC">Dictates how the paper of the main UI looks like.</Entry>
+
+    <Entry key="FANCY_PAPER_SHADE_NAME">Faction UI Theme Paper Shading</Entry>
+    <Entry key="FANCY_PAPER_SHADE_DESC">Dictates how dark or light the faction paper color will be.</Entry>
 
     <Entry key="FANCY_UI_METAL_NAME">Custom UI Theme Metal Color</Entry>
-    <Entry key="FANCY_UI_METAL_DESC">Dictates how the metal of the main UI loooks like.</Entry>
+    <Entry key="FANCY_UI_METAL_DESC">Dictates how the metal of the main UI looks like.</Entry>
+
+    <Entry key="FANCY_METAL_SHADE_NAME">Faction UI Theme Metal Shading</Entry>
+    <Entry key="FANCY_METAL_SHADE_DESC">Dictates how dark or light the faction metal color will be.</Entry>
 
     <Entry key="FANCY_UI_LEATHER_NAME">Custom UI Theme Leather Color</Entry>
-    <Entry key="FANCY_UI_LEATHER_DESC">Dictates how the leather of the main UI loooks like.</Entry>
+    <Entry key="FANCY_UI_LEATHER_DESC">Dictates how the leather of the main UI looks like.</Entry>
+
+    <Entry key="FANCY_LEATHER_SHADE_NAME">Faction UI Theme Leather Shading</Entry>
+    <Entry key="FANCY_LEATHER_SHADE_DESC">Dictates how dark or light the faction leather color will be.</Entry>
 
     <Entry key="FANCY_UI_WAX_NAME">Custom UI Theme Wax Color</Entry>
-    <Entry key="FANCY_UI_WAX_DESC">Dictates how the wax of the main UI loooks like.</Entry>
+    <Entry key="FANCY_UI_WAX_DESC">Dictates how the wax of the main UI looks like.</Entry>
+
+    <Entry key="FANCY_WAX_SHADE_NAME">Faction UI Theme Wax Shading</Entry>
+    <Entry key="FANCY_WAX_SHADE_DESC">Dictates how dark or light the faction wax color will be.</Entry>
 
     <Entry key="FANCY_UI_WOOD_NAME">Custom UI Theme Wood Color</Entry>
-    <Entry key="FANCY_UI_WOOD_DESC">Dictates how the wood of the main UI loooks like.</Entry>
+    <Entry key="FANCY_UI_WOOD_DESC">Dictates how the wood of the main UI looks like.</Entry>
 
+    <Entry key="FANCY_WOOD_SHADE_NAME">Faction UI Theme Wood Shading</Entry>
+    <Entry key="FANCY_WOOD_SHADE_DESC">Dictates how dark or light the faction wood color will be.</Entry>
+    
     <Entry key="FANCY_DUMP_SHEETS_NAME">Dump Sprite Sheets</Entry>
     <Entry key="FANCY_DUMP_SHEETS_DESC">Toggles whether game sprite sheets are dumped so pack debugging is possible.</Entry>
 

--- a/Source/UI/DownloaderUI.cs
+++ b/Source/UI/DownloaderUI.cs
@@ -119,7 +119,7 @@ public class DownloaderUI : UIController
     public void GoBack()
     {
         gameObject.SetActive(false);
-        FancyUI.Instance.Page = PackType.Settings;
+        FancyUI.Instance.Page = PackType.Testing;
         FancyUI.Instance.gameObject.SetActive(true);
     }
 

--- a/Source/UI/FancyUI.cs
+++ b/Source/UI/FancyUI.cs
@@ -85,7 +85,7 @@ public class FancyUI : UIController
 
     private void OpenSettings()
     {
-        Page = PackType.Settings;
+        Page = PackType.Testing;
 
         if (SettingsAndTestingUI.Instance)
         {

--- a/Source/UI/SettingsAndTestingUI.cs
+++ b/Source/UI/SettingsAndTestingUI.cs
@@ -194,7 +194,7 @@ public class SettingsAndTestingUI : UIController
 
     private void OpenTesting()
     {
-        Page = PackType.Settings;
+        Page = PackType.Testing;
         RefreshOptions();
     }
 

--- a/Source/Utils.cs
+++ b/Source/Utils.cs
@@ -670,4 +670,15 @@ public static class Utils
 
         return text2;
     }
+
+    public static Color ShadeColor(this Color color, float Darkness = 0)
+    {
+        bool IsDarker = Darkness >= 0; 
+        if (!IsDarker) Darkness = -Darkness;
+        float Weight = IsDarker ? 0 : Darkness; 
+        float R = (color.r + Weight) / (Darkness + 1);
+        float G = (color.g + Weight) / (Darkness + 1);
+        float B = (color.b + Weight) / (Darkness + 1);
+        return new Color(R, G, B, color.a);
+    }
 }


### PR DESCRIPTION
When the UI Theme is set to Faction, your wood will be colored based on your faction.
You may customize the darkness of the colors.
The higher the number, the darker it is.
The lower the number, the lighter it is.

Pirate
![image](https://github.com/user-attachments/assets/f79bdbf1-aa03-46db-ba7a-75014ed0e7b2)
Jester
![image](https://github.com/user-attachments/assets/07207c5c-ec5d-4ae4-92cc-6d140eac11b7)
Pestilence
![image](https://github.com/user-attachments/assets/1a5316d0-7ef4-49e9-8b19-b5501233deee)
Necromancer
![image](https://github.com/user-attachments/assets/0967a165-b2e1-43a8-a840-695e8333f8c1)
Amnesiac (Hawks)
![image](https://github.com/user-attachments/assets/5113dcf7-2c25-4e51-bb59-c83e339386c9)
Jailor
![image](https://github.com/user-attachments/assets/1942ddf4-9a7f-4732-8ca4-e09b8bb78485)
