### PR TITLE
Fix fire not being colored

### DIFF
--- a/Source/Patches/CWPatches.cs
+++ b/Source/Patches/CWPatches.cs
@@ -82,6 +82,7 @@ public static class SpecialAbilityPanelPatch1
 
         og.SetImageColor(ColorType.Wood); // Main wood container
         copy.SetImageColor(ColorType.Metal); // The metal support
+        __instance.useButton.transform.GetChild(0).GetComponent<Image>().SetImageColor(ColorType.Flame);
     }
 
     public static SpecialAbilityPanel cachedSpecialAbilityPanel;


### PR DESCRIPTION
There were literally 0 lines of code looking for the fire. It wasn't a broken check, it was that the check didn't exist...