### PR TITLE
The hotfix I posted in #builds

### DIFF
--- a/Source/Patches/CWPatches.cs
+++ b/Source/Patches/CWPatches.cs
@@ -682,7 +682,7 @@ public static class PatchRoleSelectionPanel
             foreach (var tab in __instance.tabInstances)
             {
                 tab.transform.GetComponent<Image>().SetImageColor(ColorType.Wood);
-                tab.transform.GetChild(0).GetComponent<TextMeshProUGUI>().SetGraphicColor(ColorType.Metal);
+                tab.transform.GetChild(0).GetComponent<TextMeshProUGUI>().SetGraphicColor(ColorType.Wood);
             }
 
             __instance.transform.GetChild(1).GetChild(0).GetComponent<Image>().SetImageColor(ColorType.Wood);


### PR DESCRIPTION
Preview: 
![image](https://github.com/user-attachments/assets/42ea8c7b-90bf-4378-9bbb-49e7944dc928)
